### PR TITLE
Added methods to capture transaction request

### DIFF
--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -11,7 +11,7 @@ namespace UsaEPay.NET.Tests
         public void Setup()
         {
             // TODO: Read these settings in from local configs
-            _client = new UsaEPayClient("v2", "_V87Qtb513Cd3vabM7RC0TbtJWeSo8p7", "123456", "abcdefghijklmnop", true);
+            _client = new UsaEPayClient("", "", "", "", true);
         }
 
         [Test]

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -141,6 +141,17 @@ namespace UsaEPay.NET.Tests
 
         [Test]
         [TestCase("")]
+        public async Task TestCapture(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.CaptureRequest(transactionKey);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("")]
         public async Task TestReleaseFunds(string transactionKey)
         {
             var request = UsaEPayRequestFactory.ReleaseFundsRequest(transactionKey);

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -11,7 +11,7 @@ namespace UsaEPay.NET.Tests
         public void Setup()
         {
             // TODO: Read these settings in from local configs
-            _client = new UsaEPayClient("", "", "", "", true);
+            _client = new UsaEPayClient("v2", "_V87Qtb513Cd3vabM7RC0TbtJWeSo8p7", "123456", "abcdefghijklmnop", true);
         }
 
         [Test]
@@ -141,9 +141,9 @@ namespace UsaEPay.NET.Tests
 
         [Test]
         [TestCase("")]
-        public async Task TestCapture(string transactionKey)
+        public async Task TestCapturePayment(string transactionKey)
         {
-            var request = UsaEPayRequestFactory.CaptureErrorRequest(transactionKey);
+            var request = UsaEPayRequestFactory.CapturePaymentRequest(transactionKey);
 
             var response = await _client.SendRequest(request);
 
@@ -152,9 +152,31 @@ namespace UsaEPay.NET.Tests
 
         [Test]
         [TestCase("")]
-        public async Task TestCaptureError(string transactionKey)
+        public async Task TestCapturePaymentError(string transactionKey)
         {
-            var request = UsaEPayRequestFactory.CaptureRequest(transactionKey);
+            var request = UsaEPayRequestFactory.CapturePaymentErrorRequest(transactionKey);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("")]
+        public async Task TestCapturePaymentReauth(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.CapturePaymentReauthRequest(transactionKey);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("")]
+        public async Task TestCapturePaymentOverride(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.CapturePaymentOverrideRequest(transactionKey);
 
             var response = await _client.SendRequest(request);
 

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -11,7 +11,7 @@ namespace UsaEPay.NET.Tests
         public void Setup()
         {
             // TODO: Read these settings in from local configs
-            _client = new UsaEPayClient("", "", "", "", true);
+            _client = new UsaEPayClient("v2", "_V87Qtb513Cd3vabM7RC0TbtJWeSo8p7", "123456", "abcdefghijklmnop", true);
         }
 
         [Test]
@@ -142,6 +142,17 @@ namespace UsaEPay.NET.Tests
         [Test]
         [TestCase("")]
         public async Task TestCapture(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.CaptureErrorRequest(transactionKey);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("")]
+        public async Task TestCaptureError(string transactionKey)
         {
             var request = UsaEPayRequestFactory.CaptureRequest(transactionKey);
 

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -1,5 +1,4 @@
 using UsaEPay.NET.Factories;
-using UsaEPay.NET.Models.Classes;
 
 namespace UsaEPay.NET.Tests
 {
@@ -11,7 +10,7 @@ namespace UsaEPay.NET.Tests
         public void Setup()
         {
             // TODO: Read these settings in from local configs
-            _client = new UsaEPayClient("v2", "_V87Qtb513Cd3vabM7RC0TbtJWeSo8p7", "123456", "abcdefghijklmnop", true);
+            _client = new UsaEPayClient("", "", "", "", true);
         }
 
         [Test]

--- a/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
+++ b/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
@@ -289,7 +289,7 @@ namespace UsaEPay.NET.Factories
             };
         }
 
-        public static UsaEPayRequest CaptureRequest(string tranKey)
+        public static UsaEPayRequest CapturePaymentRequest(string tranKey)
         {
             return new UsaEPayRequest
             {
@@ -300,7 +300,29 @@ namespace UsaEPay.NET.Factories
             };
         }
 
-        public static UsaEPayRequest CaptureErrorRequest(string tranKey)
+        public static UsaEPayRequest CapturePaymentReauthRequest(string tranKey)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:capture:reauth",
+                TransactionKey = tranKey
+            };
+        }
+
+        public static UsaEPayRequest CapturePaymentOverrideRequest(string tranKey)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:capture:override",
+                TransactionKey = tranKey
+            };
+        }
+
+        public static UsaEPayRequest CapturePaymentErrorRequest(string tranKey)
         {
             return new UsaEPayRequest
             {

--- a/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
+++ b/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
@@ -289,6 +289,17 @@ namespace UsaEPay.NET.Factories
             };
         }
 
+        public static UsaEPayRequest CaptureRequest(string tranKey)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:capture",
+                TransactionKey = tranKey
+            };
+        }
+
         public static UsaEPayRequest CreditVoidRequest(string tranKey)
         {
             return new UsaEPayRequest

--- a/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
+++ b/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
@@ -300,6 +300,17 @@ namespace UsaEPay.NET.Factories
             };
         }
 
+        public static UsaEPayRequest CaptureErrorRequest(string tranKey)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:capture:error",
+                TransactionKey = tranKey
+            };
+        }
+
         public static UsaEPayRequest CreditVoidRequest(string tranKey)
         {
             return new UsaEPayRequest


### PR DESCRIPTION
CapturePaymentRequest - this method captures transactions that have not yet expired and errs expired transactions according to your settings in [API Keys].

CapturePaymentErrorRequest- This method captures transactions that have not yet expired and if the authorization has expired, the command will throw an error.

CapturePaymentReauthRequest - This method captures transactions that have not yet expired and if the authorization has expired, it will attempt to reauthorize the same card.

CapturePaymentOverrideRequest - This method captures transactions that have not yet expired and if the authorization has expired it will force a capture, even if the authorization has exceeded the maximum 30 days. We would not recommend capturing transactions over 60 days due to the charge back risk.

