### PR TITLE
Added methods to AdjustPayment Transactions

### DIFF
--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -183,6 +183,28 @@ namespace UsaEPay.NET.Tests
         }
 
         [Test]
+        [TestCase("")]
+        public async Task TestAdjustPayment(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.AdjustPaymentRequest(transactionKey);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
+        [TestCase("")]
+        public async Task TestAdjustPaymentRefund(string transactionKey)
+        {
+            var request = UsaEPayRequestFactory.AdjustPaymentRefundRequest(transactionKey, 10);
+
+            var response = await _client.SendRequest(request);
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        [Test]
         public async Task TestTokenizeCard()
         {
             var request = UsaEPayRequestFactory.TokenizeCardRequest("John Doe", "4000100011112224", "0924", 123);

--- a/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
+++ b/UsaEPay.NET/Factories/UsaEPayRequestFactory.cs
@@ -351,6 +351,29 @@ namespace UsaEPay.NET.Factories
             };
         }
 
+        public static UsaEPayRequest AdjustPaymentRequest(string tranKey)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:adjust",
+                TransactionKey = tranKey
+            };
+        }
+
+        public static UsaEPayRequest AdjustPaymentRefundRequest(string transKey, decimal amount)
+        {
+            return new UsaEPayRequest
+            {
+                Endpoint = "transactions",
+                RequestType = RestSharp.Method.Post,
+                Command = "cc:refund:adjust",
+                TransactionKey = transKey,
+                Amount = amount
+            };
+        }
+
         public static UsaEPayRequest TokenizeCardRequest(string cardHolder, string creditCardNumber, string expiration, int cvc)
         {
             return new UsaEPayRequest


### PR DESCRIPTION
TestAdjustPayment - This method is useful when you need to modify certain parameters of a transaction before it is settled.
 
TestAdjustPaymentRefund  - This method is useful when you need to adjust the amount of a refund for a credit card transaction, providing flexibility in managing refunds for both unsettled and settled transactions.