### PR TITLE
Migrate to TUnit and add comprehensive test coverage (193 tests)

### DIFF
--- a/UsaEPay.NET.Tests/IntegrationTests/AvsTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/AvsTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Configuration;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.IntegrationTests;
+
+public sealed class AvsTests
+{
+    private IConfiguration _config = null!;
+    private UsaEPayClient _client = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<AvsTests>()
+            .Build();
+
+        _client = new UsaEPayClient(
+            _config["API_URL"]!,
+            _config["API_KEY"]!,
+            _config["API_PIN"]!,
+            _config["RANDOM_SEED"]!,
+            true);
+    }
+
+    [Test, Category("AVS")]
+    [Arguments("4000100011112224", "123", "YYY")]
+    [Arguments("4000100211112222", "999", "NYZ")]
+    [Arguments("4000100411112220", "999", "YNA")]
+    [Arguments("4000100511112229", "999", "NNN")]
+    [Arguments("4000100811112226", "999", "XXR")]
+    [Arguments("4000100911112225", "999", "XXS")]
+    public async Task Sale_AvsVariation_ReturnsExpectedCode(string cardNumber, string cvv, string expectedAvs)
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "AVS Test",
+            FirstName = "AVS",
+            LastName = "Test",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = cardNumber,
+            Expiration = "0929",
+            Cvc = cvv
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+        await Assert.That(response.AVS).IsNotNull();
+        await Assert.That(response.AVS!.ResultCode).IsEqualTo(expectedAvs);
+    }
+}

--- a/UsaEPay.NET.Tests/IntegrationTests/AvsTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/AvsTests.cs
@@ -25,6 +25,12 @@ public sealed class AvsTests
             true);
     }
 
+    [After(Test)]
+    public void Teardown()
+    {
+        _client?.Dispose();
+    }
+
     [Test, Category("AVS")]
     [Arguments("4000100011112224", "123", "YYY")]
     [Arguments("4000100211112222", "999", "NYZ")]

--- a/UsaEPay.NET.Tests/IntegrationTests/CardBrandTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/CardBrandTests.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Configuration;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.IntegrationTests;
+
+public sealed class CardBrandTests
+{
+    private IConfiguration _config = null!;
+    private UsaEPayClient _client = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<CardBrandTests>()
+            .Build();
+
+        _client = new UsaEPayClient(
+            _config["API_URL"]!,
+            _config["API_KEY"]!,
+            _config["API_PIN"]!,
+            _config["RANDOM_SEED"]!,
+            true);
+    }
+
+    [Test, Category("CardBrand")]
+    public async Task Sale_Visa_Approved_WithAvsAndCvv()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "John Doe",
+            FirstName = "John",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+        await Assert.That(response.AVS).IsNotNull();
+        await Assert.That(response.AVS!.ResultCode).IsEqualTo("YYY");
+        await Assert.That(response.CVC).IsNotNull();
+        await Assert.That(response.CVC!.ResultCode).IsEqualTo("M");
+    }
+
+    [Test, Category("CardBrand")]
+    public async Task Sale_MasterCard_Approved_WithCvvMatch()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "Jane Doe",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "5555444433332226",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+        await Assert.That(response.CVC).IsNotNull();
+        await Assert.That(response.CVC!.ResultCode).IsEqualTo("M");
+    }
+
+    [Test, Category("CardBrand")]
+    public async Task Sale_Amex_Approved_WithCvvMatch()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "Jane Doe",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "371122223332225",
+            Expiration = "0929",
+            Cvc = "1234"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+        await Assert.That(response.CVC).IsNotNull();
+        await Assert.That(response.CVC!.ResultCode).IsEqualTo("M");
+    }
+
+    [Test, Category("CardBrand")]
+    public async Task Sale_Discover_Approved_WithCvvMatch()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "Jane Doe",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "6011222233332224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+        await Assert.That(response.CVC).IsNotNull();
+        await Assert.That(response.CVC!.ResultCode).IsEqualTo("M");
+    }
+}

--- a/UsaEPay.NET.Tests/IntegrationTests/CardBrandTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/CardBrandTests.cs
@@ -25,6 +25,12 @@ public sealed class CardBrandTests
             true);
     }
 
+    [After(Test)]
+    public void Teardown()
+    {
+        _client?.Dispose();
+    }
+
     [Test, Category("CardBrand")]
     public async Task Sale_Visa_Approved_WithAvsAndCvv()
     {

--- a/UsaEPay.NET.Tests/IntegrationTests/DeclineTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/DeclineTests.cs
@@ -25,6 +25,12 @@ public sealed class DeclineTests
             true);
     }
 
+    [After(Test)]
+    public void Teardown()
+    {
+        _client?.Dispose();
+    }
+
     [Test, Category("Decline")]
     [Arguments("4000300011112220", "999", "Generic decline")]
     [Arguments("4000300211112228", "999", "Do not Honor (code 05)")]

--- a/UsaEPay.NET.Tests/IntegrationTests/DeclineTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/DeclineTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Configuration;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.IntegrationTests;
+
+public sealed class DeclineTests
+{
+    private IConfiguration _config = null!;
+    private UsaEPayClient _client = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<DeclineTests>()
+            .Build();
+
+        _client = new UsaEPayClient(
+            _config["API_URL"]!,
+            _config["API_KEY"]!,
+            _config["API_PIN"]!,
+            _config["RANDOM_SEED"]!,
+            true);
+    }
+
+    [Test, Category("Decline")]
+    [Arguments("4000300011112220", "999", "Generic decline")]
+    [Arguments("4000300211112228", "999", "Do not Honor (code 05)")]
+    [Arguments("4000300611112224", "999", "Insufficient funds (code 51)")]
+    [Arguments("4000300811112222", "999", "Transaction not permitted (code 57)")]
+    [Arguments("4000300911112221", "999", "Restricted card (code 62)")]
+    [Arguments("4000301311112225", "999", "CVV failure (code 97)")]
+    public async Task Sale_DeclineCard_ReturnsDeclined(string cardNumber, string cvv, string description)
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            AccountHolder = "Test Decline",
+            FirstName = "Test",
+            LastName = "Decline",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = cardNumber,
+            Expiration = "0929",
+            Cvc = cvv
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("D");
+    }
+}

--- a/UsaEPay.NET.Tests/IntegrationTests/ErrorTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/ErrorTests.cs
@@ -14,7 +14,7 @@ public sealed class ErrorTests
             .AddUserSecrets<ErrorTests>()
             .Build();
 
-        var client = new UsaEPayClient(
+        using var client = new UsaEPayClient(
             config["API_URL"]!,
             config["API_KEY"]!,
             config["API_PIN"]!,
@@ -44,7 +44,7 @@ public sealed class ErrorTests
             .AddUserSecrets<ErrorTests>()
             .Build();
 
-        var client = new UsaEPayClient(
+        using var client = new UsaEPayClient(
             config["API_URL"]!,
             config["API_KEY"]!,
             config["API_PIN"]!,

--- a/UsaEPay.NET.Tests/IntegrationTests/ErrorTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/ErrorTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Configuration;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.IntegrationTests;
+
+public sealed class ErrorTests
+{
+    [Test, Category("Error")]
+    public async Task SendRequest_DisposedClient_ThrowsObjectDisposedException()
+    {
+        var config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<ErrorTests>()
+            .Build();
+
+        var client = new UsaEPayClient(
+            config["API_URL"]!,
+            config["API_KEY"]!,
+            config["API_PIN"]!,
+            config["RANDOM_SEED"]!,
+            true);
+
+        client.Dispose();
+
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "Test User",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        await Assert.That(async () => await client.SendRequest<UsaEPayResponse>(request))
+            .ThrowsExactly<ObjectDisposedException>();
+    }
+
+    [Test, Category("Error")]
+    public async Task SendRequest_CancelledToken_ThrowsOperationCanceledException()
+    {
+        var config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<ErrorTests>()
+            .Build();
+
+        var client = new UsaEPayClient(
+            config["API_URL"]!,
+            config["API_KEY"]!,
+            config["API_PIN"]!,
+            config["RANDOM_SEED"]!,
+            true);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 1,
+            AccountHolder = "Test User",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        await Assert.That(async () => await client.SendRequest<UsaEPayResponse>(request, cts.Token))
+            .ThrowsException();
+    }
+}

--- a/UsaEPay.NET.Tests/IntegrationTests/PartialAuthTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/PartialAuthTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Configuration;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.IntegrationTests;
+
+public sealed class PartialAuthTests
+{
+    private IConfiguration _config = null!;
+    private UsaEPayClient _client = null!;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        _config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<PartialAuthTests>()
+            .Build();
+
+        _client = new UsaEPayClient(
+            _config["API_URL"]!,
+            _config["API_KEY"]!,
+            _config["API_PIN"]!,
+            _config["RANDOM_SEED"]!,
+            true);
+    }
+
+    [Test, Category("PartialAuth")]
+    public async Task Sale_PartialAuth50Percent_ReturnsPartialApproval()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 100.00m,
+            AccountHolder = "Partial Test",
+            FirstName = "Partial",
+            LastName = "Test",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "4000000011112275",
+            Expiration = "0929",
+            Cvc = "999"
+        });
+        request.AmountDetail = new AmountDetail { EnablePartialAuth = true };
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("P");
+        await Assert.That(response.AmountAuthorized).IsNotNull();
+
+        var authAmount = decimal.Parse(response.AmountAuthorized!);
+        await Assert.That(authAmount).IsEqualTo(50.00m);
+    }
+
+    [Test, Category("PartialAuth")]
+    public async Task Sale_PartialAuth75Percent_ReturnsPartialApproval()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 100.00m,
+            AccountHolder = "Partial Test",
+            FirstName = "Partial",
+            LastName = "Test",
+            Address = "555 Test Street",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "4000000011112283",
+            Expiration = "0929",
+            Cvc = "999"
+        });
+        request.AmountDetail = new AmountDetail { EnablePartialAuth = true };
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("P");
+        await Assert.That(response.AmountAuthorized).IsNotNull();
+
+        var authAmount = decimal.Parse(response.AmountAuthorized!);
+        await Assert.That(authAmount).IsEqualTo(75.00m);
+    }
+}

--- a/UsaEPay.NET.Tests/IntegrationTests/PartialAuthTests.cs
+++ b/UsaEPay.NET.Tests/IntegrationTests/PartialAuthTests.cs
@@ -25,6 +25,12 @@ public sealed class PartialAuthTests
             true);
     }
 
+    [After(Test)]
+    public void Teardown()
+    {
+        _client?.Dispose();
+    }
+
     [Test, Category("PartialAuth")]
     public async Task Sale_PartialAuth50Percent_ReturnsPartialApproval()
     {
@@ -50,7 +56,7 @@ public sealed class PartialAuthTests
         await Assert.That(response!.ResultCode).IsEqualTo("P");
         await Assert.That(response.AmountAuthorized).IsNotNull();
 
-        var authAmount = decimal.Parse(response.AmountAuthorized!);
+        var authAmount = decimal.Parse(response.AmountAuthorized!, System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(authAmount).IsEqualTo(50.00m);
     }
 
@@ -79,7 +85,7 @@ public sealed class PartialAuthTests
         await Assert.That(response!.ResultCode).IsEqualTo("P");
         await Assert.That(response.AmountAuthorized).IsNotNull();
 
-        var authAmount = decimal.Parse(response.AmountAuthorized!);
+        var authAmount = decimal.Parse(response.AmountAuthorized!, System.Globalization.CultureInfo.InvariantCulture);
         await Assert.That(authAmount).IsEqualTo(75.00m);
     }
 }

--- a/UsaEPay.NET.Tests/UnitTests/AuthenticationTests.cs
+++ b/UsaEPay.NET.Tests/UnitTests/AuthenticationTests.cs
@@ -1,0 +1,119 @@
+using System.Security.Cryptography;
+using System.Text;
+using TUnit.Core;
+using UsaEPay.NET.Models.Authentication;
+
+namespace UsaEPay.NET.Tests.UnitTests;
+
+public sealed class AuthenticationTests
+{
+    [Test]
+    public async Task Constructor_KnownVector_ProducesCorrectAuthKey()
+    {
+        // Arrange
+        var seed = "abcdefghijklmnop";
+        var apiKey = "testkey";
+        var apiPin = "1234";
+
+        var prehash = apiKey + seed + apiPin; // "testkeyabcdefghijklmnop1234"
+        var sha256Hex = ComputeSha256Hex(prehash);
+        var expectedApiHash = "s2/" + seed + "/" + sha256Hex;
+        var expectedBase64 = Convert.ToBase64String(Encoding.ASCII.GetBytes(apiKey + ":" + expectedApiHash));
+        var expectedAuthKey = "Basic " + expectedBase64;
+
+        // Act
+        var auth = new Authentication(seed, apiKey, apiPin);
+
+        // Assert
+        await Assert.That(auth.AuthKey).IsEqualTo(expectedAuthKey);
+    }
+
+    [Test]
+    public async Task Constructor_KnownVector_AuthKeyStartsWithBasic()
+    {
+        // Arrange & Act
+        var auth = new Authentication("abcdefghijklmnop", "testkey", "1234");
+
+        // Assert
+        await Assert.That(auth.AuthKey).StartsWith("Basic ");
+    }
+
+    [Test]
+    public async Task Constructor_KnownVector_AuthKeyContainsBase64()
+    {
+        // Arrange & Act
+        var auth = new Authentication("abcdefghijklmnop", "testkey", "1234");
+
+        // Assert — the base64 portion should decode without throwing
+        var base64Part = auth.AuthKey["Basic ".Length..];
+        var decoded = Encoding.ASCII.GetString(Convert.FromBase64String(base64Part));
+        await Assert.That(decoded).StartsWith("testkey:");
+    }
+
+    [Test]
+    public async Task Constructor_KnownVector_HashFormatContainsSeedAndSha256()
+    {
+        // Arrange
+        var seed = "abcdefghijklmnop";
+        var apiKey = "testkey";
+        var apiPin = "1234";
+
+        // Act
+        var auth = new Authentication(seed, apiKey, apiPin);
+
+        // Extract the apihash from the decoded base64
+        var base64Part = auth.AuthKey["Basic ".Length..];
+        var decoded = Encoding.ASCII.GetString(Convert.FromBase64String(base64Part));
+        var colonIndex = decoded.IndexOf(':');
+        var apihash = decoded[(colonIndex + 1)..];
+
+        // Assert — hash format is "s2/<seed>/<sha256hex>"
+        await Assert.That(apihash).StartsWith("s2/" + seed + "/");
+
+        // The SHA256 hex portion should be 64 characters
+        var parts = apihash.Split('/');
+        await Assert.That(parts).HasCount().EqualTo(3);
+        await Assert.That(parts[2]).HasLength().EqualTo(64);
+    }
+
+    [Test]
+    public async Task Constructor_KnownVector_PrehashIsConcatenationOfKeyAndSeedAndPin()
+    {
+        // Arrange
+        var seed = "myseed";
+        var apiKey = "mykey";
+        var apiPin = "mypin";
+        var expectedPrehash = "mykeymyseedmypin";
+        var expectedSha256 = ComputeSha256Hex(expectedPrehash);
+
+        // Act
+        var auth = new Authentication(seed, apiKey, apiPin);
+
+        // Extract hash
+        var base64Part = auth.AuthKey["Basic ".Length..];
+        var decoded = Encoding.ASCII.GetString(Convert.FromBase64String(base64Part));
+        var apihash = decoded[(decoded.IndexOf(':') + 1)..];
+        var sha256Part = apihash.Split('/')[2];
+
+        // Assert
+        await Assert.That(sha256Part).IsEqualTo(expectedSha256);
+    }
+
+    [Test]
+    public async Task Constructor_SetsProperties()
+    {
+        // Arrange & Act
+        var auth = new Authentication("seed1", "key1", "pin1");
+
+        // Assert
+        await Assert.That(auth.Seed).IsEqualTo("seed1");
+        await Assert.That(auth.ApiKey).IsEqualTo("key1");
+        await Assert.That(auth.ApiPin).IsEqualTo("pin1");
+    }
+
+    private static string ComputeSha256Hex(string input)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/UsaEPay.NET.Tests/UnitTests/ClientTests.cs
+++ b/UsaEPay.NET.Tests/UnitTests/ClientTests.cs
@@ -1,0 +1,50 @@
+using TUnit.Core;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.UnitTests;
+
+public sealed class ClientTests
+{
+    [Test]
+    [Arguments(null, "key", "pin", "seed")]
+    [Arguments("", "key", "pin", "seed")]
+    [Arguments(" ", "key", "pin", "seed")]
+    [Arguments("url", null, "pin", "seed")]
+    [Arguments("url", "", "pin", "seed")]
+    [Arguments("url", " ", "pin", "seed")]
+    [Arguments("url", "key", null, "seed")]
+    [Arguments("url", "key", "", "seed")]
+    [Arguments("url", "key", " ", "seed")]
+    [Arguments("url", "key", "pin", null)]
+    [Arguments("url", "key", "pin", "")]
+    [Arguments("url", "key", "pin", " ")]
+    public async Task Constructor_NullOrEmptyArgs_ThrowsArgumentException(
+        string? apiUrl, string? apiKey, string? apiPin, string? randomSeed)
+    {
+        await Assert.That(() => new UsaEPayClient(apiUrl!, apiKey!, apiPin!, randomSeed!))
+            .ThrowsException();
+    }
+
+    [Test]
+    public async Task Constructor_ValidArgs_DoesNotThrow()
+    {
+        using var client = new UsaEPayClient("v2", "testkey", "1234", "randomseed", useSandbox: true);
+        await Assert.That(client).IsNotNull();
+    }
+
+    [Test]
+    public async Task Disposed_Client_ThrowsObjectDisposedException()
+    {
+        var client = new UsaEPayClient("v2", "testkey", "1234", "randomseed", useSandbox: true);
+        client.Dispose();
+
+        var request = new UsaEPayRequest
+        {
+            Endpoint = "transactions",
+            Command = "cc:sale"
+        };
+
+        await Assert.That(async () => await client.SendRequest<UsaEPayResponse>(request))
+            .ThrowsExactly<ObjectDisposedException>();
+    }
+}

--- a/UsaEPay.NET.Tests/UnitTests/ConverterTests.cs
+++ b/UsaEPay.NET.Tests/UnitTests/ConverterTests.cs
@@ -1,0 +1,305 @@
+using System.Text.Json;
+using TUnit.Core;
+using UsaEPay.NET.Converter;
+using UsaEPay.NET.Models.Enumerations.Event;
+
+namespace UsaEPay.NET.Tests.UnitTests;
+
+public sealed class ConverterTests
+{
+    #region ParseStringToDecimalConverter
+
+    [Test]
+    public async Task DecimalConverter_StringValue_ParsesCorrectly()
+    {
+        var json = """{"value":"10.50"}""";
+        var result = JsonSerializer.Deserialize<DecimalHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(10.50m);
+    }
+
+    [Test]
+    public async Task DecimalConverter_NullValue_ReturnsZero()
+    {
+        var json = """{"value":null}""";
+        var result = JsonSerializer.Deserialize<DecimalHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(0m);
+    }
+
+    [Test]
+    public async Task DecimalConverter_NumberToken_ReturnsDecimal()
+    {
+        var json = """{"value":25.75}""";
+        var result = JsonSerializer.Deserialize<DecimalHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(25.75m);
+    }
+
+    [Test]
+    public async Task DecimalConverter_InvalidString_ThrowsJsonException()
+    {
+        var json = """{"value":"notanumber"}""";
+        await Assert.That(() => JsonSerializer.Deserialize<DecimalHolder>(json)).ThrowsExactly<JsonException>();
+    }
+
+    private sealed class DecimalHolder
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(ParseStringToDecimalConverter))]
+        public decimal Value { get; set; }
+    }
+
+    #endregion
+
+    #region ParseStringToLongConverter
+
+    [Test]
+    public async Task LongConverter_StringValue_ParsesCorrectly()
+    {
+        var json = """{"value":"100"}""";
+        var result = JsonSerializer.Deserialize<LongHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(100L);
+    }
+
+    [Test]
+    public async Task LongConverter_NumberToken_ReturnsLong()
+    {
+        var json = """{"value":100}""";
+        var result = JsonSerializer.Deserialize<LongHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(100L);
+    }
+
+    [Test]
+    public async Task LongConverter_NullValue_ReturnsZero()
+    {
+        var json = """{"value":null}""";
+        var result = JsonSerializer.Deserialize<LongHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task LongConverter_InvalidString_ThrowsJsonException()
+    {
+        var json = """{"value":"abc"}""";
+        await Assert.That(() => JsonSerializer.Deserialize<LongHolder>(json)).ThrowsExactly<JsonException>();
+    }
+
+    private sealed class LongHolder
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(ParseStringToLongConverter))]
+        public long Value { get; set; }
+    }
+
+    #endregion
+
+    #region ParseStringToDoubleConverter
+
+    [Test]
+    public async Task DoubleConverter_StringValue_ParsesCorrectly()
+    {
+        var json = """{"value":"3.14"}""";
+        var result = JsonSerializer.Deserialize<DoubleHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(3.14);
+    }
+
+    [Test]
+    public async Task DoubleConverter_NumberToken_ReturnsDouble()
+    {
+        var json = """{"value":2.71}""";
+        var result = JsonSerializer.Deserialize<DoubleHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(2.71);
+    }
+
+    [Test]
+    public async Task DoubleConverter_NullValue_ReturnsZero()
+    {
+        var json = """{"value":null}""";
+        var result = JsonSerializer.Deserialize<DoubleHolder>(json);
+        await Assert.That(result!.Value).IsEqualTo(0.0);
+    }
+
+    [Test]
+    public async Task DoubleConverter_InvalidString_ThrowsJsonException()
+    {
+        var json = """{"value":"xyz"}""";
+        await Assert.That(() => JsonSerializer.Deserialize<DoubleHolder>(json)).ThrowsExactly<JsonException>();
+    }
+
+    private sealed class DoubleHolder
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(ParseStringToDoubleConverter))]
+        public double Value { get; set; }
+    }
+
+    #endregion
+
+    #region USAePayStringToDateTimeOffsetConverter
+
+    [Test]
+    public async Task DateTimeOffsetConverter_ValidFormat_ParsesCorrectly()
+    {
+        var json = """{"value":"2024-01-15 10:30:00"}""";
+        var result = JsonSerializer.Deserialize<DateTimeOffsetHolder>(json);
+        var parsedLocal = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Local);
+        var expected = new DateTimeOffset(parsedLocal);
+        await Assert.That(result!.Value).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task DateTimeOffsetConverter_NullValue_ReturnsNull()
+    {
+        var json = """{"value":null}""";
+        var result = JsonSerializer.Deserialize<DateTimeOffsetHolder>(json);
+        await Assert.That(result!.Value).IsNull();
+    }
+
+    [Test]
+    public async Task DateTimeOffsetConverter_EmptyString_ReturnsNull()
+    {
+        var json = """{"value":""}""";
+        var result = JsonSerializer.Deserialize<DateTimeOffsetHolder>(json);
+        await Assert.That(result!.Value).IsNull();
+    }
+
+    [Test]
+    public async Task DateTimeOffsetConverter_InvalidFormat_ThrowsException()
+    {
+        var json = """{"value":"not-a-date"}""";
+        await Assert.That(() => JsonSerializer.Deserialize<DateTimeOffsetHolder>(json)).ThrowsException();
+    }
+
+    [Test]
+    public async Task DateTimeOffsetConverter_Write_FormatsCorrectly()
+    {
+        var holder = new DateTimeOffsetHolder { Value = new DateTimeOffset(2024, 6, 15, 14, 30, 0, TimeSpan.Zero) };
+        var json = JsonSerializer.Serialize(holder);
+        await Assert.That(json).Contains("2024-06-15 14:30:00");
+    }
+
+    [Test]
+    public async Task DateTimeOffsetConverter_WriteNull_WritesNull()
+    {
+        var holder = new DateTimeOffsetHolder { Value = null };
+        var json = JsonSerializer.Serialize(holder);
+        await Assert.That(json).Contains("null");
+    }
+
+    private sealed class DateTimeOffsetHolder
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        [System.Text.Json.Serialization.JsonConverter(typeof(USAePayStringToDateTimeOffsetConverter))]
+        public DateTimeOffset? Value { get; set; }
+    }
+
+    #endregion
+
+    #region EventTypeConverter
+
+    [Test]
+    [Arguments("ach.submitted", EventType.AchSubmitted)]
+    [Arguments("ach.settled", EventType.AchSettled)]
+    [Arguments("ach.returned", EventType.AchReturned)]
+    [Arguments("ach.voided", EventType.AchVoided)]
+    [Arguments("ach.failed", EventType.AchFailed)]
+    [Arguments("ach.note_added", EventType.AchNoteAdded)]
+    [Arguments("product.inventory.ordered", EventType.ProductInventoryOrdered)]
+    [Arguments("product.inventory.adjusted", EventType.ProductInventoryAdjusted)]
+    [Arguments("transaction.sale.success", EventType.TransactionSaleSuccess)]
+    [Arguments("transaction.sale.failure", EventType.TransactionSaleFailure)]
+    [Arguments("transaction.sale.voided", EventType.TransactionSaleVoided)]
+    [Arguments("transaction.sale.captured", EventType.TransactionSaleCaptured)]
+    [Arguments("transaction.sale.adjusted", EventType.TransactionSaleAdjusted)]
+    [Arguments("transaction.sale.queued", EventType.TransactionSaleQueued)]
+    [Arguments("transaction.sale.unvoided", EventType.TransactionSaleUnvoided)]
+    [Arguments("transaction.refund.success", EventType.TransactionRefundSuccess)]
+    [Arguments("transaction.refund.voided", EventType.TransactionRefundVoided)]
+    [Arguments("settlement.batch.success", EventType.SettlementBatchSuccess)]
+    [Arguments("settlement.batch.failure", EventType.SettlementBatchFailure)]
+    public async Task EventTypeConverter_Read_ParsesCorrectly(string jsonValue, EventType expected)
+    {
+        var json = "\"" + jsonValue + "\"";
+        var result = JsonSerializer.Deserialize<EventType>(json);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("cardupdate.created", EventType.CauCreated)]
+    [Arguments("cardupdate.submitted", EventType.CauSubmitted)]
+    [Arguments("cardupdate.updated_expiration", EventType.CauUpdatedExpiration)]
+    [Arguments("cardupdate.updated_card", EventType.CauUpdatedCard)]
+    [Arguments("cardupdate.contact_customer", EventType.CauContactCustomer)]
+    [Arguments("cardupdate.account_closed", EventType.CauAccountClosed)]
+    public async Task EventTypeConverter_Read_CardupdatePrefix_ParsesCorrectly(string jsonValue, EventType expected)
+    {
+        var json = "\"" + jsonValue + "\"";
+        var result = JsonSerializer.Deserialize<EventType>(json);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("cau.created", EventType.CauCreated)]
+    [Arguments("cau.submitted", EventType.CauSubmitted)]
+    [Arguments("cau.updated_expiration", EventType.CauUpdatedExpiration)]
+    [Arguments("cau.updated_card", EventType.CauUpdatedCard)]
+    [Arguments("cau.contact_customer", EventType.CauContactCustomer)]
+    [Arguments("cau.account_closed", EventType.CauAccountClosed)]
+    public async Task EventTypeConverter_Read_CauPrefix_ParsesCorrectly(string jsonValue, EventType expected)
+    {
+        var json = "\"" + jsonValue + "\"";
+        var result = JsonSerializer.Deserialize<EventType>(json);
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task EventTypeConverter_Read_UnknownValue_ThrowsJsonException()
+    {
+        var json = "\"unknown.event\"";
+        await Assert.That(() => JsonSerializer.Deserialize<EventType>(json)).ThrowsExactly<JsonException>();
+    }
+
+    [Test]
+    [Arguments(EventType.AchSubmitted, "ach.submitted")]
+    [Arguments(EventType.AchSettled, "ach.settled")]
+    [Arguments(EventType.AchReturned, "ach.returned")]
+    [Arguments(EventType.AchVoided, "ach.voided")]
+    [Arguments(EventType.AchFailed, "ach.failed")]
+    [Arguments(EventType.AchNoteAdded, "ach.note_added")]
+    [Arguments(EventType.CauCreated, "cardupdate.created")]
+    [Arguments(EventType.CauSubmitted, "cardupdate.submitted")]
+    [Arguments(EventType.CauUpdatedExpiration, "cardupdate.updated_expiration")]
+    [Arguments(EventType.CauUpdatedCard, "cardupdate.updated_card")]
+    [Arguments(EventType.CauContactCustomer, "cardupdate.contact_customer")]
+    [Arguments(EventType.CauAccountClosed, "cardupdate.account_closed")]
+    [Arguments(EventType.ProductInventoryOrdered, "product.inventory.ordered")]
+    [Arguments(EventType.ProductInventoryAdjusted, "product.inventory.adjusted")]
+    [Arguments(EventType.TransactionSaleSuccess, "transaction.sale.success")]
+    [Arguments(EventType.TransactionSaleFailure, "transaction.sale.failure")]
+    [Arguments(EventType.TransactionSaleVoided, "transaction.sale.voided")]
+    [Arguments(EventType.TransactionSaleCaptured, "transaction.sale.captured")]
+    [Arguments(EventType.TransactionSaleAdjusted, "transaction.sale.adjusted")]
+    [Arguments(EventType.TransactionSaleQueued, "transaction.sale.queued")]
+    [Arguments(EventType.TransactionSaleUnvoided, "transaction.sale.unvoided")]
+    [Arguments(EventType.TransactionRefundSuccess, "transaction.refund.success")]
+    [Arguments(EventType.TransactionRefundVoided, "transaction.refund.voided")]
+    [Arguments(EventType.SettlementBatchSuccess, "settlement.batch.success")]
+    [Arguments(EventType.SettlementBatchFailure, "settlement.batch.failure")]
+    public async Task EventTypeConverter_Write_SerializesCorrectly(EventType eventType, string expectedString)
+    {
+        var json = JsonSerializer.Serialize(eventType);
+        await Assert.That(json).IsEqualTo($"\"{expectedString}\"");
+    }
+
+    [Test]
+    [Arguments(EventType.AchSubmitted)]
+    [Arguments(EventType.CauCreated)]
+    [Arguments(EventType.TransactionSaleSuccess)]
+    [Arguments(EventType.SettlementBatchSuccess)]
+    public async Task EventTypeConverter_RoundTrip_PreservesValue(EventType original)
+    {
+        var json = JsonSerializer.Serialize(original);
+        var deserialized = JsonSerializer.Deserialize<EventType>(json);
+        await Assert.That(deserialized).IsEqualTo(original);
+    }
+
+    #endregion
+}

--- a/UsaEPay.NET.Tests/UnitTests/FactoryTests.cs
+++ b/UsaEPay.NET.Tests/UnitTests/FactoryTests.cs
@@ -1,0 +1,453 @@
+using RestSharp;
+using TUnit.Core;
+using UsaEPay.NET.Factories;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.UnitTests;
+
+public sealed class FactoryTests
+{
+    #region CreditCardSaleRequest
+
+    [Test]
+    public async Task CreditCardSaleRequest_SetsCorrectEndpoint()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.Endpoint).IsEqualTo(UsaEPayEndpoints.Transactions);
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_SetsCorrectCommand()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.TransactionSale);
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_SetsPostMethod()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.RequestType).IsEqualTo(Method.Post);
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_MapsBillingAddress()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.BillingAddress).IsNotNull();
+        await Assert.That(request.BillingAddress!.FirstName).IsEqualTo("John");
+        await Assert.That(request.BillingAddress!.LastName).IsEqualTo("Doe");
+        await Assert.That(request.BillingAddress!.Street).IsEqualTo("123 Main St");
+        await Assert.That(request.BillingAddress!.City).IsEqualTo("Anytown");
+        await Assert.That(request.BillingAddress!.State).IsEqualTo("CA");
+        await Assert.That(request.BillingAddress!.PostalCode).IsEqualTo("90210");
+        await Assert.That(request.BillingAddress!.Country).IsEqualTo("USA");
+        await Assert.That(request.BillingAddress!.Phone).IsEqualTo("5551234567");
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_MapsCreditCard()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.CreditCard).IsNotNull();
+        await Assert.That(request.CreditCard!.Number).IsEqualTo("4111111111111111");
+        await Assert.That(request.CreditCard!.Cvc).IsEqualTo("123");
+        await Assert.That(request.CreditCard!.Expiration).IsEqualTo("1225");
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_WithCustomFields_SetsCustomFields()
+    {
+        var tranParams = CreateSampleCardParams();
+        var customFields = new Dictionary<string, string> { { "custom1", "value1" } };
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams, customFields);
+        await Assert.That(request.CustomFields).IsNotNull();
+        await Assert.That(request.CustomFields!["custom1"]).IsEqualTo("value1");
+    }
+
+    [Test]
+    public async Task CreditCardSaleRequest_WithoutCustomFields_CustomFieldsIsNull()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(tranParams);
+        await Assert.That(request.CustomFields).IsNull();
+    }
+
+    #endregion
+
+    #region CheckSaleRequest
+
+    [Test]
+    public async Task CheckSaleRequest_SetsCheckFields()
+    {
+        var tranParams = CreateSampleCheckParams();
+        var request = UsaEPayRequestFactory.CheckSaleRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CheckSale);
+        await Assert.That(request.Check).IsNotNull();
+        await Assert.That(request.Check!.Number).IsEqualTo("1001");
+        await Assert.That(request.Check!.Account).IsEqualTo("123456789");
+        await Assert.That(request.Check!.Routing).IsEqualTo("021000021");
+        await Assert.That(request.Check!.AccountType).IsEqualTo("checking");
+    }
+
+    #endregion
+
+    #region TokenSaleRequest
+
+    [Test]
+    public async Task TokenSaleRequest_PassesCustomFields()
+    {
+        var tranParams = CreateSampleCardParams();
+        tranParams.Token = "tok_abc123";
+        var customFields = new Dictionary<string, string> { { "field1", "val1" }, { "field2", "val2" } };
+        var request = UsaEPayRequestFactory.TokenSaleRequest(tranParams, customFields);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.TransactionSale);
+        await Assert.That(request.CreditCard!.Number).IsEqualTo("tok_abc123");
+        await Assert.That(request.CustomFields).IsNotNull();
+        await Assert.That(request.CustomFields!.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TokenSaleRequest_WithoutCustomFields_SetsCustomFieldsNull()
+    {
+        var tranParams = CreateSampleCardParams();
+        tranParams.Token = "tok_abc123";
+        var request = UsaEPayRequestFactory.TokenSaleRequest(tranParams);
+        await Assert.That(request.CustomFields).IsNull();
+    }
+
+    #endregion
+
+    #region QuickSaleRequest
+
+    [Test]
+    public async Task QuickSaleRequest_WithTransactionKey_SetsTransactionKey()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 10m, TransactionKey = "tkey123" };
+        var request = UsaEPayRequestFactory.QuickSaleRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.QuickSale);
+        await Assert.That(request.TransactionKey).IsEqualTo("tkey123");
+        await Assert.That(request.ReferenceNumber).IsNull();
+    }
+
+    [Test]
+    public async Task QuickSaleRequest_WithRefnum_FallsBackToRefnum()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 10m, Refnum = "ref456" };
+        var request = UsaEPayRequestFactory.QuickSaleRequest(tranParams);
+        await Assert.That(request.ReferenceNumber).IsEqualTo("ref456");
+        await Assert.That(request.TransactionKey).IsNull();
+    }
+
+    [Test]
+    public async Task QuickSaleRequest_WithBoth_PrefersTransactionKey()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 10m, TransactionKey = "tkey123", Refnum = "ref456" };
+        var request = UsaEPayRequestFactory.QuickSaleRequest(tranParams);
+        await Assert.That(request.TransactionKey).IsEqualTo("tkey123");
+        await Assert.That(request.ReferenceNumber).IsNull();
+    }
+
+    #endregion
+
+    #region QuickRefundRequest
+
+    [Test]
+    public async Task QuickRefundRequest_WithTransactionKey_SetsTransactionKey()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 5m, TransactionKey = "tkey789" };
+        var request = UsaEPayRequestFactory.QuickRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.QuickRefund);
+        await Assert.That(request.TransactionKey).IsEqualTo("tkey789");
+    }
+
+    [Test]
+    public async Task QuickRefundRequest_WithRefnum_FallsBackToRefnum()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 5m, Refnum = "ref999" };
+        var request = UsaEPayRequestFactory.QuickRefundRequest(tranParams);
+        await Assert.That(request.ReferenceNumber).IsEqualTo("ref999");
+        await Assert.That(request.TransactionKey).IsNull();
+    }
+
+    #endregion
+
+    #region Capture/Void/Refund Commands
+
+    [Test]
+    public async Task CapturePaymentRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.CapturePaymentRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CapturePayment);
+        await Assert.That(request.TransactionKey).IsEqualTo("tk1");
+    }
+
+    [Test]
+    public async Task CapturePaymentReauthRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.CapturePaymentReauthRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CapturePaymentReauth);
+    }
+
+    [Test]
+    public async Task CapturePaymentOverrideRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.CapturePaymentOverrideRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CapturePaymentOverride);
+    }
+
+    [Test]
+    public async Task CapturePaymentErrorRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.CapturePaymentErrorRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CapturePaymentError);
+    }
+
+    [Test]
+    public async Task CreditVoidRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.CreditVoidRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CreditVoid);
+    }
+
+    [Test]
+    public async Task VoidPaymentRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.VoidPaymentRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.VoidPayment);
+    }
+
+    [Test]
+    public async Task CreditCardRefundRequest_SetsCorrectCommand()
+    {
+        var tranParams = CreateSampleCardParams();
+        var request = UsaEPayRequestFactory.CreditCardRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CreditCardRefund);
+    }
+
+    [Test]
+    public async Task CheckRefundRequest_SetsCorrectCommand()
+    {
+        var tranParams = CreateSampleCheckParams();
+        var request = UsaEPayRequestFactory.CheckRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CheckRefund);
+    }
+
+    [Test]
+    public async Task ConnectedRefundRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 10m, TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.ConnectedRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.Refund);
+    }
+
+    [Test]
+    public async Task CashRefundRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { Amount = 10m };
+        var request = UsaEPayRequestFactory.CashRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CashRefund);
+    }
+
+    [Test]
+    public async Task ReleaseFundsRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.ReleaseFundsRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.ReleaseFunds);
+    }
+
+    [Test]
+    public async Task UnvoidRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.UnvoidRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.Unvoid);
+    }
+
+    [Test]
+    public async Task AdjustPaymentRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1" };
+        var request = UsaEPayRequestFactory.AdjustPaymentRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.AdjustPayment);
+    }
+
+    [Test]
+    public async Task AdjustPaymentRefundRequest_SetsCorrectCommand()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk1", Amount = 5m };
+        var request = UsaEPayRequestFactory.AdjustPaymentRefundRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.AdjustPaymentRefund);
+        await Assert.That(request.Amount).IsEqualTo(5m);
+    }
+
+    #endregion
+
+    #region CustomerSaleRequest
+
+    [Test]
+    public async Task CustomerSaleRequest_UsesCustkeyAndPaymethodKey()
+    {
+        var tranParams = new UsaEPayTransactionParams
+        {
+            Amount = 50m,
+            CustomerKey = "cust_abc",
+            PaymentMethodKey = "pm_xyz"
+        };
+        var request = UsaEPayRequestFactory.CustomerSaleRequest(tranParams);
+        await Assert.That(request.Command).IsEqualTo(UsaEPayCommandTypes.CustomerSale);
+        await Assert.That(request.CustomerKey).IsEqualTo("cust_abc");
+        await Assert.That(request.PaymentMethodKey).IsEqualTo("pm_xyz");
+        await Assert.That(request.Amount).IsEqualTo(50m);
+    }
+
+    #endregion
+
+    #region GET Request Methods
+
+    [Test]
+    public async Task RetrieveTransactionDetailsRequest_UsesGetMethod()
+    {
+        var tranParams = new UsaEPayTransactionParams { TransactionKey = "tk123" };
+        var request = UsaEPayRequestFactory.RetrieveTransactionDetailsRequest(tranParams);
+        await Assert.That(request.RequestType).IsEqualTo(Method.Get);
+        await Assert.That(request.Endpoint).IsEqualTo("transactions/tk123");
+    }
+
+    [Test]
+    public async Task RetrieveSpecificBatchRequest_UsesGetMethod()
+    {
+        var request = UsaEPayRequestFactory.RetrieveSpecificBatchRequest("batch_key_1");
+        await Assert.That(request.RequestType).IsEqualTo(Method.Get);
+        await Assert.That(request.Endpoint).IsEqualTo("batches/batch_key_1");
+    }
+
+    [Test]
+    public async Task RetrieveBatchListRequest_UsesGetMethod()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchListRequest(10, 5);
+        await Assert.That(request.RequestType).IsEqualTo(Method.Get);
+        await Assert.That(request.Endpoint).IsEqualTo("batches?limit=10&offset=5");
+    }
+
+    [Test]
+    public async Task RetrieveCurrentBatchRequest_UsesGetMethod()
+    {
+        var request = UsaEPayRequestFactory.RetrieveCurrentBatchRequest();
+        await Assert.That(request.RequestType).IsEqualTo(Method.Get);
+        await Assert.That(request.Endpoint).IsEqualTo("batches/current");
+    }
+
+    [Test]
+    public async Task RetrieveTokenDetailsRequest_UsesGetMethod()
+    {
+        var tranParams = new UsaEPayTransactionParams { Token = "tok_abc" };
+        var request = UsaEPayRequestFactory.RetrieveTokenDetailsRequest(tranParams);
+        await Assert.That(request.RequestType).IsEqualTo(Method.Get);
+        await Assert.That(request.Endpoint).IsEqualTo("tokens/tok_abc");
+    }
+
+    #endregion
+
+    #region RetrieveBatchListByDateRequest
+
+    [Test]
+    public async Task RetrieveBatchListByDateRequest_BuildsCorrectQueryParams()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchListByDateRequest(
+            openedBefore: "2024-01-01",
+            openedAfter: "2023-01-01",
+            closedBefore: "2024-06-01",
+            closedAfter: "2023-06-01",
+            limit: 50,
+            offset: 10);
+        await Assert.That(request.Endpoint).Contains("limit=50");
+        await Assert.That(request.Endpoint).Contains("offset=10");
+        await Assert.That(request.Endpoint).Contains("openedlt=2024-01-01");
+        await Assert.That(request.Endpoint).Contains("openedge=2023-01-01");
+        await Assert.That(request.Endpoint).Contains("closedlt=2024-06-01");
+        await Assert.That(request.Endpoint).Contains("closedge=2023-06-01");
+    }
+
+    [Test]
+    public async Task RetrieveBatchListByDateRequest_NullDates_OmitsDateParams()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchListByDateRequest(limit: 20, offset: 0);
+        await Assert.That(request.Endpoint).Contains("limit=20");
+        await Assert.That(request.Endpoint).Contains("offset=0");
+        await Assert.That(request.Endpoint).DoesNotContain("openedlt");
+        await Assert.That(request.Endpoint).DoesNotContain("openedge");
+        await Assert.That(request.Endpoint).DoesNotContain("closedlt");
+        await Assert.That(request.Endpoint).DoesNotContain("closedge");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static UsaEPayTransactionParams CreateSampleCardParams()
+    {
+        return new UsaEPayTransactionParams
+        {
+            Amount = 100.00m,
+            CardNumber = "4111111111111111",
+            Cvc = "123",
+            Expiration = "1225",
+            AccountHolder = "John Doe",
+            FirstName = "John",
+            LastName = "Doe",
+            Address = "123 Main St",
+            Address2 = "Apt 4",
+            City = "Anytown",
+            State = "CA",
+            Zip = "90210",
+            Country = "USA",
+            Phone = "5551234567",
+            Email = "john@example.com",
+            Description = "Test sale",
+            Invoice = "INV-001",
+            OrderId = "ORD-001",
+            ClientIP = "192.168.1.1"
+        };
+    }
+
+    private static UsaEPayTransactionParams CreateSampleCheckParams()
+    {
+        return new UsaEPayTransactionParams
+        {
+            Amount = 75.00m,
+            CheckNumber = "1001",
+            Account = "123456789",
+            Routing = "021000021",
+            AccountType = "checking",
+            AccountHolder = "Jane Doe",
+            FirstName = "Jane",
+            LastName = "Doe",
+            Address = "456 Oak Ave",
+            City = "Othertown",
+            State = "NY",
+            Zip = "10001",
+            Country = "USA",
+            Phone = "5559876543",
+            Email = "jane@example.com",
+            Description = "Check sale test",
+            Invoice = "INV-002",
+            OrderId = "ORD-002",
+            ClientIP = "10.0.0.1"
+        };
+    }
+
+    #endregion
+}

--- a/UsaEPay.NET.Tests/UnitTests/SerializationTests.cs
+++ b/UsaEPay.NET.Tests/UnitTests/SerializationTests.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using TUnit.Core;
+using UsaEPay.NET.Models;
+using UsaEPay.NET.Models.Classes;
+
+namespace UsaEPay.NET.Tests.UnitTests;
+
+public sealed class SerializationTests
+{
+    #region Request Serialization
+
+    [Test]
+    public async Task Request_Serializes_CommandField()
+    {
+        var request = new UsaEPayRequest
+        {
+            Command = "cc:sale",
+            Amount = 10.00m,
+            CreditCard = new CreditCard
+            {
+                Number = "4111111111111111",
+                Cvc = "123",
+                Expiration = "1225"
+            },
+            BillingAddress = new Address
+            {
+                FirstName = "John",
+                LastName = "Doe"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(json).Contains("\"command\":\"cc:sale\"");
+        await Assert.That(json).Contains("\"number\":\"4111111111111111\"");
+        await Assert.That(json).Contains("\"first_name\":\"John\"");
+    }
+
+    [Test]
+    public async Task Request_Serializes_CreditCardObject()
+    {
+        var request = new UsaEPayRequest
+        {
+            Command = "cc:sale",
+            CreditCard = new CreditCard
+            {
+                Number = "4242424242424242",
+                Cvc = "456",
+                Expiration = "0326",
+                CardHolder = "Jane Smith"
+            }
+        };
+
+        var json = JsonSerializer.Serialize(request, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(json).Contains("\"creditcard\"");
+        await Assert.That(json).Contains("\"number\":\"4242424242424242\"");
+        await Assert.That(json).Contains("\"cvc\":\"456\"");
+        await Assert.That(json).Contains("\"expiration\":\"0326\"");
+        await Assert.That(json).Contains("\"cardholder\":\"Jane Smith\"");
+    }
+
+    [Test]
+    public async Task Request_NullFields_OmittedFromJson()
+    {
+        var request = new UsaEPayRequest
+        {
+            Command = "cc:sale",
+            Amount = 5.00m
+        };
+
+        var json = JsonSerializer.Serialize(request, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(json).DoesNotContain("\"creditcard\"");
+        await Assert.That(json).DoesNotContain("\"billing_address\"");
+        await Assert.That(json).DoesNotContain("\"shipping_address\"");
+        await Assert.That(json).DoesNotContain("\"custom_fields\"");
+        await Assert.That(json).DoesNotContain("\"trankey\"");
+        await Assert.That(json).DoesNotContain("\"refnum\"");
+        await Assert.That(json).DoesNotContain("\"invoice\"");
+    }
+
+    [Test]
+    public async Task Request_DefaultBoolFields_OmittedFromJson()
+    {
+        var request = new UsaEPayRequest
+        {
+            Command = "cc:sale"
+        };
+
+        var json = JsonSerializer.Serialize(request, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(json).DoesNotContain("\"save_card\"");
+        await Assert.That(json).DoesNotContain("\"save_customer\"");
+        await Assert.That(json).DoesNotContain("\"send_receipt\"");
+        await Assert.That(json).DoesNotContain("\"ignore_duplicate\"");
+    }
+
+    #endregion
+
+    #region Response Deserialization
+
+    [Test]
+    public async Task Response_Deserializes_FromSampleJson()
+    {
+        var json = """
+        {
+            "type": "transaction",
+            "key": "tnx_abc123",
+            "refnum": "100099",
+            "result_code": "A",
+            "result": "Approved",
+            "authcode": "345678",
+            "status_code": "P",
+            "status": "Pending",
+            "creditcard": {
+                "number": "4111xxxxxxxx1111",
+                "cvc": "123",
+                "expiration": "1225"
+            },
+            "invoice": "INV-001",
+            "amount": "50.00",
+            "billing_address": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "street": "123 Main St"
+            }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<UsaEPayResponse>(json, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Type).IsEqualTo("transaction");
+        await Assert.That(response.Key).IsEqualTo("tnx_abc123");
+        await Assert.That(response.ReferenceNumber).IsEqualTo("100099");
+        await Assert.That(response.ResultCode).IsEqualTo("A");
+        await Assert.That(response.Result).IsEqualTo("Approved");
+        await Assert.That(response.AuthCode).IsEqualTo("345678");
+        await Assert.That(response.Amount).IsEqualTo(50.00m);
+        await Assert.That(response.Invoice).IsEqualTo("INV-001");
+        await Assert.That(response.CreditCard).IsNotNull();
+        await Assert.That(response.CreditCard!.Number).IsEqualTo("4111xxxxxxxx1111");
+        await Assert.That(response.BillingAddress).IsNotNull();
+        await Assert.That(response.BillingAddress!.FirstName).IsEqualTo("John");
+    }
+
+    [Test]
+    public async Task Response_Deserializes_WithMissingOptionalFields()
+    {
+        var json = """
+        {
+            "type": "transaction",
+            "key": "tnx_minimal",
+            "result_code": "A",
+            "result": "Approved",
+            "amount": "10.00"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<UsaEPayResponse>(json, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Key).IsEqualTo("tnx_minimal");
+        await Assert.That(response.CreditCard).IsNull();
+        await Assert.That(response.BillingAddress).IsNull();
+        await Assert.That(response.Check).IsNull();
+        await Assert.That(response.Batch).IsNull();
+    }
+
+    #endregion
+
+    #region BatchListResponse Deserialization
+
+    [Test]
+    public async Task BatchListResponse_Deserializes_Correctly()
+    {
+        var json = """
+        {
+            "type": "list",
+            "limit": "20",
+            "offset": "0",
+            "total": "2",
+            "data": [
+                {
+                    "type": "batch",
+                    "key": "batch_001",
+                    "batchrefnum": "1001",
+                    "status": "closed",
+                    "opened": "2024-01-01 08:00:00",
+                    "closed": "2024-01-01 20:00:00",
+                    "total_amount": 5000.00,
+                    "total_count": "50",
+                    "sales_amount": 4500.00,
+                    "sales_count": "45",
+                    "voids_amount": 200.00,
+                    "voids_count": "2",
+                    "refunds_amount": 300.00,
+                    "refunds_count": "3"
+                },
+                {
+                    "type": "batch",
+                    "key": "batch_002",
+                    "batchrefnum": "1002",
+                    "status": "open"
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<UsaEPayBatchListResponse>(json, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Type).IsEqualTo("list");
+        await Assert.That(response.Limit).IsEqualTo(20L);
+        await Assert.That(response.Offset).IsEqualTo(0L);
+        await Assert.That(response.Total).IsEqualTo(2L);
+        await Assert.That(response.Data).HasCount().EqualTo(2);
+        await Assert.That(response.Data[0].Key).IsEqualTo("batch_001");
+        await Assert.That(response.Data[0].BatchReferenceNumber).IsEqualTo(1001L);
+        await Assert.That(response.Data[0].Status).IsEqualTo("closed");
+        await Assert.That(response.Data[0].TotalAmount).IsEqualTo(5000.00m);
+        await Assert.That(response.Data[0].TotalCount).IsEqualTo(50L);
+        await Assert.That(response.Data[0].SalesCount).IsEqualTo(45L);
+        await Assert.That(response.Data[1].Key).IsEqualTo("batch_002");
+        await Assert.That(response.Data[1].Status).IsEqualTo("open");
+    }
+
+    #endregion
+
+    #region Amount as String Deserialization
+
+    [Test]
+    public async Task Response_AmountAsString_DeserializesCorrectly()
+    {
+        var json = """
+        {
+            "type": "transaction",
+            "key": "tnx_amount_string",
+            "result_code": "A",
+            "result": "Approved",
+            "amount": "123.45"
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<UsaEPayResponse>(json, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(response!.Amount).IsEqualTo(123.45m);
+    }
+
+    [Test]
+    public async Task Response_AmountAsNumber_DeserializesCorrectly()
+    {
+        var json = """
+        {
+            "type": "transaction",
+            "key": "tnx_amount_num",
+            "result_code": "A",
+            "result": "Approved",
+            "amount": 67.89
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<UsaEPayResponse>(json, USAePaySerializerContext.Default.Options);
+
+        await Assert.That(response!.Amount).IsEqualTo(67.89m);
+    }
+
+    #endregion
+}

--- a/UsaEPay.NET.Tests/UsaEPay.NET.Tests.csproj
+++ b/UsaEPay.NET.Tests/UsaEPay.NET.Tests.csproj
@@ -1,11 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <UserSecretsId>4cc5d884-60c2-4ffd-ac59-49bf3f54b1ca</UserSecretsId>
   </PropertyGroup>
 
@@ -13,17 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="TUnit" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -2,513 +2,512 @@ using Microsoft.Extensions.Configuration;
 using UsaEPay.NET.Factories;
 using UsaEPay.NET.Models.Classes;
 
-namespace UsaEPay.NET.Tests
+namespace UsaEPay.NET.Tests;
+
+[NotInParallel]
+public sealed class UsaEPayClientTests
 {
-    public class Shared
+    private IConfiguration _config = null!;
+    private UsaEPayClient _client = null!;
+
+    // Shared state captured across ordered tests
+    private static string s_token = string.Empty;
+    private static string s_transKey = string.Empty;
+    private static string s_transAuthKey = string.Empty;
+    private static string s_tranCheckKey = string.Empty;
+    private static string s_batchKey = string.Empty;
+
+    [Before(Test)]
+    public void Setup()
     {
-        public static UsaEPayClient Client;
-        public static IConfiguration Config;
-        public static string Token = string.Empty;
-        public static string TransKey = string.Empty;
-        public static string TransAuthKey = string.Empty;
-        public static string TranCheckKey = string.Empty;
-        public string BatchKey = string.Empty;
+        _config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddUserSecrets<UsaEPayClientTests>()
+            .Build();
+
+        _client = new UsaEPayClient(
+            _config["API_URL"]!,
+            _config["API_KEY"]!,
+            _config["API_PIN"]!,
+            _config["RANDOM_SEED"]!,
+            true);
     }
-    [Order(1)]
-    public class Tokenization : Shared
+
+    // ── Tokenization ────────────────────────────────────────────────
+
+    [Test, Category("Token")]
+    public async Task TokenizeCard_ReturnsApproved()
     {
-        [SetUp]
-        public void Setup()
+        var request = UsaEPayRequestFactory.TokenizeCardRequest(new UsaEPayTransactionParams
         {
-            Config = new ConfigurationBuilder()
-                .AddEnvironmentVariables()
-                .AddUserSecrets<Tokenization>()
-                .Build();
-            Client = new UsaEPayClient(
-                Config["API_URL"],
-                Config["API_KEY"],
-                Config["API_PIN"],
-                Config["RANDOM_SEED"],
-                true
-                );
-        }
+            CardHolder = "John Doe",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
 
-        [Test, Order(1), Category("Token")]
-        public async Task TestTokenizeCard()
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+
+        if (response.ResultCode == "A")
         {
-            var tokenizeCardParams = new UsaEPayTransactionParams
-            {
-                CardHolder = "John Doe",
-                CardNumber = "4000100011112224",
-                Expiration = "0929",
-                Cvc = "123"
-            };
-            var request = UsaEPayRequestFactory.TokenizeCardRequest(tokenizeCardParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-            if (response.ResultCode == "A")
-            {
-                Token = response.SavedCard.Key;
-            }
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(2), Category("Token")]
-        public async Task TestTokenSale()
-        {
-            var tokenSaleParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                FirstName = "John",
-                LastName = "Doe",
-                Address = "555 Test Street",
-                Address2 = "",
-                City = "Testington",
-                State = "OK",
-                Zip = "33242",
-                Cvc = "123",
-                Token = Token
-            };
-            var request = UsaEPayRequestFactory.TokenSaleRequest(tokenSaleParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
+            s_token = response.SavedCard!.Key;
         }
     }
 
-    [Order(2)]
-    public class Transaction : Shared
+    [Test, Category("Token"), DependsOn(nameof(TokenizeCard_ReturnsApproved))]
+    public async Task TokenSale_ReturnsApproved()
     {
-        [Test, Order(1), Category("Sale")]
-        public async Task TestCardSale()
+        var request = UsaEPayRequestFactory.TokenSaleRequest(new UsaEPayTransactionParams
         {
-            var creditCardSaleParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                FirstName = "John",
-                LastName = "Doe",
-                AccountHolder = "John Doe",
-                Address = "555 Test Street",
-                Address2 = "",
-                City = "Testington",
-                State = "OK",
-                Zip = "33242",
-                CardNumber = "4000100011112224",
-                Expiration = "0929",
-                Cvc = "123"
-            };
-            var request = UsaEPayRequestFactory.CreditCardSaleRequest(creditCardSaleParams);
+            Amount = 10,
+            FirstName = "John",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            Address2 = "",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            Cvc = "123",
+            Token = s_token
+        });
 
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-            if (response.ResultCode == "A")
-            {
-                TransKey = response.Key;
-            }
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
 
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
 
-        [Test, Order(2), Category("Sale")]
-        public async Task TestQuickSale()
+    // ── Credit Card Sale ────────────────────────────────────────────
+
+    [Test, Category("Sale")]
+    public async Task CardSale_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CreditCardSaleRequest(new UsaEPayTransactionParams
         {
-            var quickSaleParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                TransactionKey = TransKey
-            };
-                var request = UsaEPayRequestFactory.QuickSaleRequest(quickSaleParams);
+            Amount = 10,
+            FirstName = "John",
+            LastName = "Doe",
+            AccountHolder = "John Doe",
+            Address = "555 Test Street",
+            Address2 = "",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
 
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
 
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
 
-        [Test, Order(3), Category("Sale")]
-        public async Task TestCheckSale()
+        if (response.ResultCode == "A")
         {
-            var checkSaleParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                FirstName = "Remus",
-                LastName = "Lupin",
-                Address = "555 Test Street",
-                Address2 = "",
-                City = "Testington",
-                State = "OK",
-                Zip = "33242",
-                Routing = "123456789",
-                Account = "324523524",
-                AccountType = "checking",
-                CheckNumber = "101"
-            };
-            var request = UsaEPayRequestFactory.CheckSaleRequest(checkSaleParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-            if (response.ResultCode == "A")
-            {
-                TranCheckKey = response.Key;
-            }
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(4), Category("Sale")]
-        public async Task TestAuthOnlySale()
-        {
-            var authOnlyParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                AccountHolder = "John Doe",
-                CardNumber = "4000100011112224",
-                Expiration = "0929",
-                Cvc = "123",
-                FirstName = "John",
-                LastName = "Doe",
-                Address = "555 Test Street",
-                Address2 = "Street 2",
-                City = "Testington",
-                State = "OK",
-                Zip = "33242",
-
-            };
-            var request = UsaEPayRequestFactory.AuthOnlySaleRequest(authOnlyParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-            if (response.ResultCode == "A")
-            {
-                TransAuthKey = response.Key;
-            }
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(5), Category("Refund")]
-        public async Task TestCreditCardRefund()
-        {
-            var refundParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                CardHolder = "John Doe",
-                CardNumber = "4000100011112224",
-                Expiration = "0929",
-                Cvc = "123"
-            };
-            var request = UsaEPayRequestFactory.CreditCardRefundRequest(refundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(6), Category("Refund")]
-        public async Task TestCheckRefund()
-        {
-            var refundParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                AccountHolder = "John Doe",
-                AccountNumber = "234234",
-                Routing = "123456789",
-                AccountType = "checking",
-                CheckNumber = "101"
-            };
-            var request = UsaEPayRequestFactory.CheckRefundRequest(refundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(7), Category("Refund")]
-        public async Task TestQuickRefund()
-        {
-            var quickRefundParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                TransactionKey = TransKey
-            };
-                var request = UsaEPayRequestFactory.QuickRefundRequest(quickRefundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(8), Category("Refund")]
-        public async Task TestConnectedRefund()
-        {
-            var connectedRefundParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                Email = "test@.com",
-                ClientIP = "10.1.0.1",
-                TransactionKey = TransAuthKey
-            };
-            var request = UsaEPayRequestFactory.ConnectedRefundRequest(connectedRefundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(9), Category("Refund")]
-        public async Task TestAdjustPaymentRefund()
-        {
-            var adjustRefundParams = new UsaEPayTransactionParams
-            {
-                Amount = 10,
-                TransactionKey = TranCheckKey
-            };
-                var request = UsaEPayRequestFactory.AdjustPaymentRefundRequest(adjustRefundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(10), Category("Capture")]
-        public async Task TestCapturePayment()
-        {
-            var adjustRefundParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.CapturePaymentRequest(adjustRefundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(11), Category("Capture")]
-        public async Task TestCapturePaymentError()
-        {
-            var captureErrorParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.CapturePaymentErrorRequest(captureErrorParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(12), Category("Capture")]
-        public async Task TestCapturePaymentReauth()
-        {
-            var captureReAuthParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.CapturePaymentReauthRequest(captureReAuthParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(13), Category("Capture")]
-        public async Task TestCapturePaymentOverride()
-        {
-            var captureOverrideParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.CapturePaymentOverrideRequest(captureOverrideParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(14), Category("Adjust")]
-        public async Task TestAdjustPayment()
-        {
-            var adjustTransactionParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.AdjustPaymentRequest(adjustTransactionParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(15), Category("RetrieveDetails")]
-        public async Task TestRetrieveTransactionDetails()
-        {
-            var retrieveTransactionParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.RetrieveTransactionDetailsRequest(retrieveTransactionParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(16), Category("Void")]
-        public async Task TestCreditVoid()
-        {
-            var voidTransactionParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.CreditVoidRequest(voidTransactionParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(17), Category("Void")]
-        public async Task TestVoidPayment()
-        {
-            var voidPaymentParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TranCheckKey
-            };
-            var request = UsaEPayRequestFactory.VoidPaymentRequest(voidPaymentParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(18), Category("Void")]
-        public async Task TestUnvoid()
-        {
-            var UnvoidPaymentParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.UnvoidRequest(UnvoidPaymentParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-        [Test, Order(19), Category("Void")]
-        public async Task TestReleaseFunds()
-        {
-            var releaseFundParams = new UsaEPayTransactionParams
-            {
-                TransactionKey = TransKey
-            };
-            var request = UsaEPayRequestFactory.ReleaseFundsRequest(releaseFundParams);
-
-            var response = await Client.SendRequest<UsaEPayResponse>(request);
-
-            Assert.That(response.ResultCode, Is.EqualTo("A"));
-        }
-
-
-        [Test, Order(20), Category("ListTransactions")]
-        public async Task TestTransactionList()
-        {
-            var request = UsaEPayRequestFactory.RetrieveTransactionsRequest(5,0);
-
-            var response = await Client.SendRequest<UsaEPayListTransactionResponse>(request);
-
-            Assert.That(response, Is.Not.Null);
+            s_transKey = response.Key;
         }
     }
 
-    [Order(3)]
-    public class Batch : Shared
+    [Test, Category("Sale"), DependsOn(nameof(CardSale_ReturnsApproved))]
+    public async Task QuickSale_ReturnsApproved()
     {
-        [Test, Order(1), Category("BatchList")]
-        public async Task TestBatchList()
+        var request = UsaEPayRequestFactory.QuickSaleRequest(new UsaEPayTransactionParams
         {
-            var request = UsaEPayRequestFactory.RetrieveBatchListRequest();
+            Amount = 10,
+            TransactionKey = s_transKey
+        });
 
-            var response = await Client.SendRequest<UsaEPayBatchListResponse>(request);
-            if (response.Data != null)
-            {
-                var batchItem = response.Data.First();
-                BatchKey = batchItem.Key;
-            }
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
 
-            Assert.That(response, Is.Not.Null);
-        }
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
 
-        [Test, Order(2), Category("BatchListByDate")]
-        [TestCase("20230101", "20240201")]
-        public async Task TestBatchListByDate(string openedAfter, string openedBefore)
+    // ── Check Sale ──────────────────────────────────────────────────
+
+    [Test, Category("Sale")]
+    public async Task CheckSale_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CheckSaleRequest(new UsaEPayTransactionParams
         {
-            var request = UsaEPayRequestFactory.RetrieveBatchListByDateRequest(openedBefore: openedBefore, openedAfter: openedAfter);
+            Amount = 10,
+            FirstName = "Remus",
+            LastName = "Lupin",
+            Address = "555 Test Street",
+            Address2 = "",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242",
+            Routing = "123456789",
+            Account = "324523524",
+            AccountType = "checking",
+            CheckNumber = "101"
+        });
 
-            var response = await Client.SendRequest<UsaEPayBatchListResponse>(request);
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
 
-            Assert.That(response.Data, Is.Not.Null);
-        }
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
 
-        [Test, Order(3), Category("RetreiveSpecificBatch")]
-        public async Task TestRetrieveSpecificBatch()
+        if (response.ResultCode == "A")
         {
-            var request = UsaEPayRequestFactory.RetrieveSpecificBatchRequest(BatchKey);
-
-            var response = await Client.SendRequest<Models.Classes.Batch>(request);
-
-            Assert.That(response.Status, Is.EqualTo("open"));
-        }
-
-        [Test, Order(4), Category("RetreiveCurrentBatch")]
-        public async Task TestRetrieveCurrentBatch()
-        {
-            var request = UsaEPayRequestFactory.RetrieveCurrentBatchRequest();
-
-            var response = await Client.SendRequest<Models.Classes.Batch>(request);
-
-            Assert.That(response.Status, Is.EqualTo("open"));
-        }
-
-        [Test, Order(5), Category("CloseCurrentBatch")]
-        public async Task TestCloseCurrentBatch()
-        {
-            var request = UsaEPayRequestFactory.CloseCurrentBatchRequest();
-
-            var response = await Client.SendRequest<Models.Classes.Batch>(request);
-
-            Assert.That(response.Status, Is.EqualTo("closing"));
-        }
-
-        
-        [Test, Order(6), Category("TestRetrieveBatchTransactionsByIdRequest")]
-        public async Task TestRetrieveBatchTransactionsByIdRequest()
-        {
-            var request = UsaEPayRequestFactory.RetrieveBatchTransactionsByIdRequest(BatchKey, 5, 1);
-
-            var response = await Client.SendRequest<UsaEPayBatchTransactionResponse>(request);
-
-            Assert.That(response, Is.Not.Null);
+            s_tranCheckKey = response.Key;
         }
     }
 
-    //[Test]
-    //[Order(8)]
-    //public async Task TestPostPayment() 
-    //{
-    //    var request = UsaEPayRequestFactory.PostPaymentRequest(10, "AUTH_CODE", "John Doe", "4000100011112224", "0924", 123);
+    // ── Auth Only ───────────────────────────────────────────────────
 
-    //    var response = await _Client.SendRequest<UsaEPayResponse>(request);
+    [Test, Category("Sale")]
+    public async Task AuthOnlySale_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.AuthOnlySaleRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            AccountHolder = "John Doe",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123",
+            FirstName = "John",
+            LastName = "Doe",
+            Address = "555 Test Street",
+            Address2 = "Street 2",
+            City = "Testington",
+            State = "OK",
+            Zip = "33242"
+        });
 
-    //    Assert.That(response.ResultCode, Is.EqualTo("A"));
-    //}
-    //[Test]
-    //[Order(29)]
-    //public async Task TestCashRefund()
-    //{
-    //    var request = UsaEPayRequestFactory.CashRefundRequest(10);
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
 
-    //    var response = await _Client.SendRequest<UsaEPayResponse>(request);
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
 
-    //    Assert.That(response.ResultCode, Is.EqualTo("A"));
-    //}
+        if (response.ResultCode == "A")
+        {
+            s_transAuthKey = response.Key;
+        }
+    }
+
+    // ── Refunds ─────────────────────────────────────────────────────
+
+    [Test, Category("Refund")]
+    public async Task CreditCardRefund_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CreditCardRefundRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            CardHolder = "John Doe",
+            CardNumber = "4000100011112224",
+            Expiration = "0929",
+            Cvc = "123"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Refund")]
+    public async Task CheckRefund_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CheckRefundRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            AccountHolder = "John Doe",
+            AccountNumber = "234234",
+            Routing = "123456789",
+            AccountType = "checking",
+            CheckNumber = "101"
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Refund"), DependsOn(nameof(CardSale_ReturnsApproved))]
+    public async Task QuickRefund_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.QuickRefundRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Refund"), DependsOn(nameof(AuthOnlySale_ReturnsApproved))]
+    public async Task ConnectedRefund_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.ConnectedRefundRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            Email = "test@.com",
+            ClientIP = "10.1.0.1",
+            TransactionKey = s_transAuthKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Refund"), DependsOn(nameof(CheckSale_ReturnsApproved))]
+    public async Task AdjustPaymentRefund_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.AdjustPaymentRefundRequest(new UsaEPayTransactionParams
+        {
+            Amount = 10,
+            TransactionKey = s_tranCheckKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    // ── Capture ─────────────────────────────────────────────────────
+
+    [Test, Category("Capture"), DependsOn(nameof(CardSale_ReturnsApproved))]
+    public async Task CapturePayment_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CapturePaymentRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Capture"), DependsOn(nameof(CapturePayment_ReturnsApproved))]
+    public async Task CapturePaymentError_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CapturePaymentErrorRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Capture"), DependsOn(nameof(CapturePaymentError_ReturnsApproved))]
+    public async Task CapturePaymentReauth_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CapturePaymentReauthRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Capture"), DependsOn(nameof(CapturePaymentReauth_ReturnsApproved))]
+    public async Task CapturePaymentOverride_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CapturePaymentOverrideRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    // ── Adjust ──────────────────────────────────────────────────────
+
+    [Test, Category("Adjust"), DependsOn(nameof(CapturePaymentOverride_ReturnsApproved))]
+    public async Task AdjustPayment_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.AdjustPaymentRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    // ── Retrieve Details ────────────────────────────────────────────
+
+    [Test, Category("RetrieveDetails"), DependsOn(nameof(AdjustPayment_ReturnsApproved))]
+    public async Task RetrieveTransactionDetails_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.RetrieveTransactionDetailsRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    // ── Void ────────────────────────────────────────────────────────
+
+    [Test, Category("Void"), DependsOn(nameof(RetrieveTransactionDetails_ReturnsApproved))]
+    public async Task CreditVoid_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.CreditVoidRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Void"), DependsOn(nameof(CheckSale_ReturnsApproved))]
+    public async Task VoidPayment_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.VoidPaymentRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_tranCheckKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Void"), DependsOn(nameof(CreditVoid_ReturnsApproved))]
+    public async Task Unvoid_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.UnvoidRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    [Test, Category("Void"), DependsOn(nameof(Unvoid_ReturnsApproved))]
+    public async Task ReleaseFunds_ReturnsApproved()
+    {
+        var request = UsaEPayRequestFactory.ReleaseFundsRequest(new UsaEPayTransactionParams
+        {
+            TransactionKey = s_transKey
+        });
+
+        var response = await _client.SendRequest<UsaEPayResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.ResultCode).IsEqualTo("A");
+    }
+
+    // ── Transaction List ────────────────────────────────────────────
+
+    [Test, Category("ListTransactions"), DependsOn(nameof(ReleaseFunds_ReturnsApproved))]
+    public async Task TransactionList_ReturnsData()
+    {
+        var request = UsaEPayRequestFactory.RetrieveTransactionsRequest(5, 0);
+
+        var response = await _client.SendRequest<UsaEPayListTransactionResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+    }
+
+    // ── Batch ───────────────────────────────────────────────────────
+
+    [Test, Category("BatchList")]
+    public async Task BatchList_ReturnsData()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchListRequest();
+
+        var response = await _client.SendRequest<UsaEPayBatchListResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+
+        if (response!.Data != null)
+        {
+            var batchItem = response.Data.First();
+            s_batchKey = batchItem.Key;
+        }
+    }
+
+    [Test, Category("BatchListByDate")]
+    public async Task BatchListByDate_ReturnsData()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchListByDateRequest(
+            openedBefore: "20240201",
+            openedAfter: "20230101");
+
+        var response = await _client.SendRequest<UsaEPayBatchListResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Data).IsNotNull();
+    }
+
+    [Test, Category("RetrieveSpecificBatch"), DependsOn(nameof(BatchList_ReturnsData))]
+    public async Task RetrieveSpecificBatch_ReturnsOpen()
+    {
+        var request = UsaEPayRequestFactory.RetrieveSpecificBatchRequest(s_batchKey);
+
+        var response = await _client.SendRequest<Models.Classes.Batch>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Status).IsEqualTo("open");
+    }
+
+    [Test, Category("RetrieveCurrentBatch")]
+    public async Task RetrieveCurrentBatch_ReturnsOpen()
+    {
+        var request = UsaEPayRequestFactory.RetrieveCurrentBatchRequest();
+
+        var response = await _client.SendRequest<Models.Classes.Batch>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Status).IsEqualTo("open");
+    }
+
+    [Test, Category("CloseCurrentBatch"), DependsOn(nameof(RetrieveCurrentBatch_ReturnsOpen))]
+    public async Task CloseCurrentBatch_ReturnsClosing()
+    {
+        var request = UsaEPayRequestFactory.CloseCurrentBatchRequest();
+
+        var response = await _client.SendRequest<Models.Classes.Batch>(request);
+
+        await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Status).IsEqualTo("closing");
+    }
+
+    [Test, Category("BatchTransactions"), DependsOn(nameof(BatchList_ReturnsData))]
+    public async Task RetrieveBatchTransactionsById_ReturnsData()
+    {
+        var request = UsaEPayRequestFactory.RetrieveBatchTransactionsByIdRequest(s_batchKey, 5, 1);
+
+        var response = await _client.SendRequest<UsaEPayBatchTransactionResponse>(request);
+
+        await Assert.That(response).IsNotNull();
+    }
 }

--- a/UsaEPay.NET.Tests/UsaEPayClientTests.cs
+++ b/UsaEPay.NET.Tests/UsaEPayClientTests.cs
@@ -33,6 +33,12 @@ public sealed class UsaEPayClientTests
             true);
     }
 
+    [After(Test)]
+    public void Teardown()
+    {
+        _client?.Dispose();
+    }
+
     // ── Tokenization ────────────────────────────────────────────────
 
     [Test, Category("Token")]
@@ -447,12 +453,10 @@ public sealed class UsaEPayClientTests
         var response = await _client.SendRequest<UsaEPayBatchListResponse>(request);
 
         await Assert.That(response).IsNotNull();
+        await Assert.That(response!.Data).IsNotNull();
+        await Assert.That(response.Data.Length).IsGreaterThan(0);
 
-        if (response!.Data != null)
-        {
-            var batchItem = response.Data.First();
-            s_batchKey = batchItem.Key;
-        }
+        s_batchKey = response.Data.First().Key;
     }
 
     [Test, Category("BatchListByDate")]

--- a/UsaEPay.NET.Tests/Usings.cs
+++ b/UsaEPay.NET.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using NUnit.Framework;

--- a/UsaEPay.NET.Tests/Usings.cs
+++ b/UsaEPay.NET.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using TUnit.Core;


### PR DESCRIPTION
## Summary

Migrates test framework from NUnit to TUnit (per SRS technology standards) and adds comprehensive unit + integration test coverage. Goes from 28 integration-only tests to **193 total tests** covering unit, integration, and edge cases.

## Test breakdown

| Category | Tests | Network? |
|----------|-------|----------|
| Authentication hash | 6 | No |
| Converter (Decimal/Long/Double/DateTime/EventType) | 42 | No |
| Factory methods | 30+ | No |
| Serialization round-trips | 6 | No |
| Client constructor/dispose | 14 | No |
| Card brand coverage (Visa/MC/Amex/Discover) | 4 | Sandbox |
| Decline handling (6 cards) | 6 | Sandbox |
| AVS response matrix (6 variations) | 6 | Sandbox |
| Partial authorization (50%/75%) | 2 | Sandbox |
| Error paths (dispose/cancel) | 2 | No |
| Existing transaction lifecycle (migrated) | 28 | Sandbox |
| EventType converter (cau. + cardupdate. prefixes) | 37 | No |

## Key changes

- **NUnit → TUnit**: Sealed classes, `await Assert.That(...)`, `[Arguments]` data-driven, `[DependsOn]` for ordered tests
- **Removed**: NUnit, NUnit3TestAdapter, NUnit.Analyzers, coverlet.collector, Microsoft.NET.Test.Sdk
- **Added**: TUnit 1.0.0 with MTP runner (`TestingPlatformDotnetTestSupport`)
- **Fixed**: Partial auth tests now set `enable_partialauth` flag

## Test results

```
total: 193, failed: 0, succeeded: 193, duration: 15s
```

## Test plan

- [x] All 193 tests pass locally
- [x] `dotnet build --configuration Release` — 0 errors
- [ ] CI pipeline (needs `dotnet run` instead of `dotnet test` for TUnit MTP on .NET 10)